### PR TITLE
Fixes #2: updated image paths to use GCP artifact registry with region prefix

### DIFF
--- a/.github/workflows/workflow-build-container.yml
+++ b/.github/workflows/workflow-build-container.yml
@@ -35,7 +35,7 @@ jobs:
           context: .
           push: true
           build-args: REACT_APP_BACKEND_URL=${{ secrets.REACT_APP_BACKEND_URL }}
-          tags: ${{ secrets.LOUIS_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}
+          tags: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.LOUIS_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}          
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/.github/workflows/workflow-build-container.yml
+++ b/.github/workflows/workflow-build-container.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           registry: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev
           username: _json_key
-          password: ${{ secrets.LOUIS_GAR_JSON_KEY }}
+          password: ${{ secrets.AI_LAB_GAR_JSON_KEY }}
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -35,7 +35,7 @@ jobs:
           context: .
           push: true
           build-args: REACT_APP_BACKEND_URL=${{ secrets.REACT_APP_BACKEND_URL }}
-          tags: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.LOUIS_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}          
+          tags: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.AI_LAB_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}          
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/.github/workflows/workflow-build-container.yml
+++ b/.github/workflows/workflow-build-container.yml
@@ -9,19 +9,27 @@ on:
       tag:
         required: true
         type: string
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Login to Google Artifact Registry (GAR)
       - name: Login to GAR
         uses: docker/login-action@v2
         with:
           registry: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev
           username: _json_key
-          password: ${{ secrets.AI_LAB_GAR_JSON_KEY }}
+          password: ${{ secrets.AILAB_GAR_JSON_KEY }}
+          
+      # Checkout the current repository
       - uses: actions/checkout@v3
+      
+      # Setup Docker Buildx for advanced build features
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        
+      # Cache Docker layers to improve build speed
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -29,15 +37,20 @@ jobs:
           key: ${{ runner.os }}-${{inputs.container-name}}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{inputs.container-name}}
+            
+      # Build and push the Docker image with the specified tag
       - name: Build the Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
+          # Build argument for React frontend
           build-args: REACT_APP_BACKEND_URL=${{ secrets.REACT_APP_BACKEND_URL }}
-          tags: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.AI_LAB_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}          
+          tags: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.AILAB_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
+          
+      # Cleanup and move cache for future builds
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/workflow-deploy-gcp.yml
+++ b/.github/workflows/workflow-deploy-gcp.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: ${{ secrets.LOUIS_GAR_JSON_KEY }}
+          credentials_json: ${{ secrets.AI_LAB_GAR_JSON_KEY }}
       - name: Deploy to Cloud Run
         # You may pin to the exact commit or the version.
         # uses: google-github-actions/deploy-cloudrun@e62f655d5754bec48078a72edc015367b01ee97b
         uses: google-github-actions/deploy-cloudrun@v1.0.2
         with:
           # Name of the container image to deploy (e.g. gcr.io/cloudrun/hello:latest). Required if not using a service YAML.
-          image: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.LOUIS_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}
+          image: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.AI_LAB_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}
           # ID of the service or fully qualified identifier for the service. Required if not using a service YAML.
           service: ${{inputs.container-name}}
           # Region in which the resource can be found.

--- a/.github/workflows/workflow-deploy-gcp.yml
+++ b/.github/workflows/workflow-deploy-gcp.yml
@@ -24,7 +24,7 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@v1.0.2
         with:
           # Name of the container image to deploy (e.g. gcr.io/cloudrun/hello:latest). Required if not using a service YAML.
-          image: ${{ secrets.LOUIS_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}
+          image: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.LOUIS_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}
           # ID of the service or fully qualified identifier for the service. Required if not using a service YAML.
           service: ${{inputs.container-name}}
           # Region in which the resource can be found.

--- a/.github/workflows/workflow-deploy-gcp.yml
+++ b/.github/workflows/workflow-deploy-gcp.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: ${{ secrets.AI_LAB_GAR_JSON_KEY }}
+          credentials_json: ${{ secrets.AILAB_GAR_JSON_KEY }}
       - name: Deploy to Cloud Run
         # You may pin to the exact commit or the version.
         # uses: google-github-actions/deploy-cloudrun@e62f655d5754bec48078a72edc015367b01ee97b
         uses: google-github-actions/deploy-cloudrun@v1.0.2
         with:
           # Name of the container image to deploy (e.g. gcr.io/cloudrun/hello:latest). Required if not using a service YAML.
-          image: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.AI_LAB_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}
+          image: ${{ secrets.GCP_CLOUDRUN_REGION }}-docker.pkg.dev/${{ secrets.AILAB_REGISTRY }}/${{inputs.container-name}}:${{inputs.tag}}
           # ID of the service or fully qualified identifier for the service. Required if not using a service YAML.
           service: ${{inputs.container-name}}
           # Region in which the resource can be found.


### PR DESCRIPTION
An error was appearing when trying to build without the region for tag which then led to the image not being found when deploying

Error message : Error: buildx failed with: ERROR: invalid tag "***/:": invalid reference format

Link for syntax : https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling#tag