### PR TITLE
Issue #90: Allow use of custom config file for yaml linting and change line length rule to 120

### DIFF
--- a/.github/workflows/workflow-build-push-container-github-registry.yml
+++ b/.github/workflows/workflow-build-push-container-github-registry.yml
@@ -112,9 +112,8 @@ jobs:
 
       - name: Install the remove-previous-image from github.com/ai-cfia/devops inside the user-site
         run: >
-          python -m pip install --user
-          git+https://$USER:$USER_TOKEN@github.com/ai-cfia/devops.git@
-          26-as-a-devops-i-want-to-create-unit-tests-for-the-remove-previous-imagepy-script
+          python -m pip install --user \
+          git+https://$USER:$USER_TOKEN@github.com/ai-cfia/devops.git@26-as-a-devops-i-want-to-create-unit-tests-for-the-remove-previous-imagepy-script
         env:
           USER: ${{ secrets.USER }}
           USER_TOKEN: ${{ secrets.USER_TOKEN }}

--- a/.github/workflows/workflow-build-push-container-github-registry.yml
+++ b/.github/workflows/workflow-build-push-container-github-registry.yml
@@ -1,3 +1,4 @@
+---
 name: Reusable workflow to build and push docker container to github container registry
 
 on:
@@ -110,7 +111,10 @@ jobs:
           python-version: 3.8
 
       - name: Install the remove-previous-image from github.com/ai-cfia/devops inside the user-site
-        run: python -m pip install --user git+https://$USER:$USER_TOKEN@github.com/ai-cfia/devops.git@26-as-a-devops-i-want-to-create-unit-tests-for-the-remove-previous-imagepy-script
+        run: >
+          python -m pip install --user
+          git+https://$USER:$USER_TOKEN@github.com/ai-cfia/devops.git@
+          26-as-a-devops-i-want-to-create-unit-tests-for-the-remove-previous-imagepy-script
         env:
           USER: ${{ secrets.USER }}
           USER_TOKEN: ${{ secrets.USER_TOKEN }}

--- a/.github/workflows/workflow-yaml-check.yml
+++ b/.github/workflows/workflow-yaml-check.yml
@@ -30,7 +30,12 @@ jobs:
           files=$(echo '${{ steps.files.outputs.all }}' | jq -r '.[]')
           for file in $files; do
             if [[ $file == *.yml || $file == *.yaml ]]; then
-              yamllint "$file"
+              # Check if a custom config path is provided and file exists
+              if [[ -n "$config_path" && -f "$config_path" ]]; then
+               yamllint -c ${{ inputs.config-file-path }} "$file"
+              else
+                yamllint "$file"
+              fi
             fi
           done
         shell: bash

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "editor.rulers": [80],
+    "editor.rulers": [120],
     "files.trimTrailingWhitespace": true,
     "files.trimFinalNewlines": true,
     "files.insertFinalNewline": true

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true


### PR DESCRIPTION
- Fix violations
- Allows the use of a config file for the reusable workflow of yaml linting
- change line length rule to 120.

Why change line length rule : 
Complex expressions, such as long strings, URLs, or detailed function calls, become harder to read and understand when split across multiple lines. It also increases development overhead for some use case where we cannot simply reduce line length.

Also, IDEs and code editors are now better equipped to handle longer lines, making the 80-character limit less relevant.