### PR TITLE
Issue #90: Update vscode line length ruling for yaml files only

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
-    "editor.rulers": [120],
+    "editor.rulers": [80],
+    "[yaml]": {
+        "editor.rulers": [120]
+    },
     "files.trimTrailingWhitespace": true,
     "files.trimFinalNewlines": true,
     "files.insertFinalNewline": true


### PR DESCRIPTION
Adressing [recomnendation](https://github.com/ai-cfia/github-workflows/pull/91) from Ricky to apply different ruler only for yaml files.