### PR TITLE
Issue #101: As a Devops, I would like to have a unified set of rules for yaml linting 

### DIFF
--- a/.github/workflows/workflow-yaml-check.md
+++ b/.github/workflows/workflow-yaml-check.md
@@ -2,20 +2,30 @@
 
 ## Overview
 
-This workflow is designed to maintain and enforce coding standards within YAML files across multiple projects within the organization. It ensures that any changes made to YAML files are consistent with the predefined standards set by the organization.
+This workflow is designed to maintain and enforce coding standards within YAML
+files across multiple projects within the organization. It ensures that any
+changes made to YAML files are consistent with the predefined standards set by
+the organization.
 
 ## Usage
 
-- **Purpose:** Validate the organization's yaml standards across projects. It is triggered by **pull requests** to ensure that any new or altered YAML files comply with these standards.
+- **Purpose:** Validate the organization's yaml standards across projects. It is
+  triggered by **pull requests** to ensure that any new or altered YAML files
+  comply with these standards.
 - **Steps**
-  - YAML Lint Test: The workflow runs a linting test on the changed YAML files using the given configuration if specified.
+  - YAML Lint Test: The workflow runs a linting test on the changed YAML files
+    using the given configuration if specified.
 - **Input:** You can specify specify a custom configuration file path for the
   yaml link check. If you have specific rules or configurations for link
-  validation, you can create a configuration file in the project you are
-  calling this workflow from and input the path to this workflow. You can
-     find the documentation for this file
+  validation, you can create a configuration file in the project you are calling
+  this workflow from and input the path to this workflow. If you omit to specify
+  a file path, the default config file from current repository will be used. You
+     can find the documentation for this file
      [here](https://yamllint.readthedocs.io/en/stable/configuration.html)
 
 ## YAML Linting Guidelines for Developers
 
-- The [fnando.linter](https://marketplace.visualstudio.com/items?itemName=fnando.linter) extension for Visual Studio Code provides a flexible linter framework, which can be used for linting YAML files.
+- The
+  [fnando.linter](https://marketplace.visualstudio.com/items?itemName=fnando.linter)
+  extension for Visual Studio Code provides a flexible linter framework, which
+  can be used for linting YAML files.

--- a/.github/workflows/workflow-yaml-check.yml
+++ b/.github/workflows/workflow-yaml-check.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+
       - name: Install yamllint
         run: pip install yamllint
 
@@ -39,7 +40,7 @@ jobs:
         run: |
           files=$(echo '${{ steps.files.outputs.all }}' | jq -r '.[]')
           for file in $files; do
-            if [[ $file == *.yml || $file == *.yaml ]]; then
+          if [[ -f "$file" && ( $file == *.yml || $file == *.yaml ) ]]; then
               # Check if a custom config path is provided and file exists
               if [ -n "${{ github.event.inputs.config-file-path }}" ]; then
                 yamllint -c "${{ github.workspace }}/${{ github.event.inputs.config-file-path }}" "$file"

--- a/.github/workflows/workflow-yaml-check.yml
+++ b/.github/workflows/workflow-yaml-check.yml
@@ -34,7 +34,9 @@ jobs:
               if [ -n "${{ github.event.inputs.config-file-path }}" ]; then
                 yamllint -c "${{ github.workspace }}/${{ github.event.inputs.config-file-path }}" "$file"
               else
-                yamllint "$file"
+                default_config_url="https://raw.githubusercontent.com/ai-cfia/github-workflows/main/.yamllint.yml"
+                curl -s -O $default_config_url
+                yamllint -c "./$(basename $default_config_url)" "$file"
               fi
             fi
           done

--- a/.github/workflows/workflow-yaml-check.yml
+++ b/.github/workflows/workflow-yaml-check.yml
@@ -31,6 +31,9 @@ jobs:
           repository: ai-cfia/github-workflows
           path: github-workflows
           ref: main
+          sparse-checkout: |
+            .yamllint.yml
+          sparse-checkout-cone-mode: false
 
       - name: Lint YAML files
         run: |

--- a/.github/workflows/workflow-yaml-check.yml
+++ b/.github/workflows/workflow-yaml-check.yml
@@ -25,6 +25,13 @@ jobs:
       - name: Install yamllint
         run: pip install yamllint
 
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: ai-cfia/github-workflows
+          path: github-workflows
+          ref: main
+
       - name: Lint YAML files
         run: |
           files=$(echo '${{ steps.files.outputs.all }}' | jq -r '.[]')
@@ -34,9 +41,7 @@ jobs:
               if [ -n "${{ github.event.inputs.config-file-path }}" ]; then
                 yamllint -c "${{ github.workspace }}/${{ github.event.inputs.config-file-path }}" "$file"
               else
-                default_config_url="https://raw.githubusercontent.com/ai-cfia/github-workflows/main/.yamllint.yml"
-                curl -s -O $default_config_url
-                yamllint -c "./$(basename $default_config_url)" "$file"
+                yamllint -c github-workflows/.yamllint.yml "$file"
               fi
             fi
           done

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,7 +1,9 @@
 ---
 extends: default
 
+ignore: |
+  .git/
+
 rules:
-  line-length:
-    max: 120
-    allow-non-breakable-inline-mappings: true
+  line-length: disable
+  truthy: disable


### PR DESCRIPTION
To provide conformity, we are adding a config yaml linting file that provides expected standards of yaml files for the organisation. Repositories using the reusable workflow for linting yaml files can simply omit to specify a config file path to use default config of the organisation.

Also fixes  https://github.com/ai-cfia/howard/issues/90