### PR TITLE
Issue #85: remove npm version from workflow since migration

### DIFF
--- a/.github/workflows/workflow-lint-test-node.yml
+++ b/.github/workflows/workflow-lint-test-node.yml
@@ -16,7 +16,7 @@ jobs:
                   cache: npm
                   node-version-file: "package.json"
             - name: install npm
-              run: npm install -g npm@9.8.1
+              run: npm install
             - name: install dependencies
               run: npm install
             - name: Run ESLint


### PR DESCRIPTION
npm specific version no longer needed for test workflow of node projects.