### PR TITLE
#85: remove node requirement

### DIFF
--- a/.github/workflows/workflow-lint-test-node.yml
+++ b/.github/workflows/workflow-lint-test-node.yml
@@ -12,9 +12,6 @@ jobs:
             - uses: actions/checkout@v3
             - name: Install Node.js
               uses: actions/setup-node@v3
-              with:
-                  cache: npm
-                  node-version-file: "package.json"
             - name: install npm
               run: npm install
             - name: install dependencies


### PR DESCRIPTION
#85
Node requirement also is no longer necessary.

- [x] remove the requirement for node version to be specified in `package.json`