### PR TITLE
Issue #128: update expired token with standarized token for workflows

### DIFF
--- a/.github/workflows/workflow-repo-standards-validation.yml
+++ b/.github/workflows/workflow-repo-standards-validation.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check branch protection
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.AILAB_OCTOKIT_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             try {


### PR DESCRIPTION
Expired token updated to use standarized token for workflows so we dont have to worry about updating it. currently failing actions on other repos because of it (https://github.com/ai-cfia/ai-cfia-ia-acia.github.io/actions/runs/9572428747/job/26391707108#logs)