### PR TITLE
Fix backend SBOM runner expression

### DIFF
--- a/.github/workflows/workflow-build-push-container-github-registry-mono.yml
+++ b/.github/workflows/workflow-build-push-container-github-registry-mono.yml
@@ -36,7 +36,7 @@ jobs:
     uses: ai-cfia/github-workflows/.github/workflows/workflow-generate-backend-sbom.yml@main
     with:
       working-directory: ${{ inputs.working-directory }}
-      runs-on: ${ { inputs.runs-on } }
+      runs-on: ${{ inputs.runs-on }}
 
   frontend-sbom:
     if: contains(inputs.working-directory, 'frontend')


### PR DESCRIPTION
## Summary

Fix the backend SBOM runner expression in the reusable build/push workflow.

## Context

The backend SBOM job was waiting indefinitely for a runner because `runs-on` was written with invalid GitHub Actions expression syntax. This caused GitHub to treat the value as a literal runner label instead of resolving it to the configured runner.